### PR TITLE
Return nil if there is no user image

### DIFF
--- a/lib/ueberauth/strategy/spotify.ex
+++ b/lib/ueberauth/strategy/spotify.ex
@@ -93,7 +93,7 @@ defmodule Ueberauth.Strategy.Spotify do
       name: user["display_name"],
       nickname: user["id"],
       email: user["email"],
-      image: hd(user["images"])["url"],
+      image: List.first(user["images"])["url"],
       urls: %{external: user["external_urls"]["spotify"], spotify: user["uri"]},
       location: user["country"]
     }


### PR DESCRIPTION
There is a bug if the user has no images, the `hd()` returns an error. Using the `List.first()` it just returns `nil`.