### PR TITLE
Add support for Ueberauth CSRF protection

### DIFF
--- a/lib/ueberauth/strategy/spotify.ex
+++ b/lib/ueberauth/strategy/spotify.ex
@@ -5,7 +5,8 @@ defmodule Ueberauth.Strategy.Spotify do
 
   use Ueberauth.Strategy,
     uid_field: :uid,
-    default_scope: "user-read-email"
+    default_scope: "user-read-email",
+    ignores_csrf_attack: false
 
   alias Ueberauth.Auth.Info
   alias Ueberauth.Auth.Credentials
@@ -22,10 +23,11 @@ defmodule Ueberauth.Strategy.Spotify do
   """
   def handle_request!(conn) do
     scopes = conn.params["scope"] || option(conn, :default_scope)
+    state = Map.get(conn.params, "state", conn.private[:ueberauth_state_param])
 
     opts = [
       scope: scopes,
-      state: Map.get(conn.params, "state", nil),
+      state: state,
       show_dialog: Map.get(conn.params, "show_dialog", nil),
       redirect_uri: callback_url(conn)
     ]


### PR DESCRIPTION
In version 0.7.0 Ueberauth [added](https://github.com/ueberauth/ueberauth/pull/136) support for CSRF protection. With this in place, `ueberauth_spotify` no longer works (in a default setup), resulting in a failure:

```
%Ueberauth.Failure{
  errors: [
    %Ueberauth.Failure.Error{
      message: "Cross-Site Request Forgery attack",
      message_key: :csrf_attack
    }
  ],
  provider: :spotify,
  strategy: Ueberauth.Strategy.Spotify
}
```

Following the [steps outlined](https://github.com/ueberauth/ueberauth/pull/138#issuecomment-828934022) by Ueberauth maintainers, I implemented the support for new mechanism, while still maintaining backwards compatibility (passing `state` as a parameter in the URL). With these changes, authorization with Spotify works well on 0.7.0.